### PR TITLE
Since Markdown doesn't transform ASCII arrows...

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ angular.module('ui.alias').constant('uiAliasConfig', {
 ## Notes
 
 * Be careful to avoid creating an alias that fires recursively  
-  Example: `<button>` -> `<ui-button>` -> `<button>`
+  Example: `<button>` &rarr; `<ui-button>` &rarr; `<button>`
 * You cannot override existing directives. Both the original *and* your alias directives will execute.
 * You can create multiple an alias for different configurations of the same directives / templates


### PR DESCRIPTION
...into real ones, I did it manually.  It would be nice if the source could remain with `->` and get a proper HTML rendering of a right arrow, but unfortunately it doesn't.  I prefer to have a nice rendering and slightly ugly source, but if you prefer a cleaner source and ugly rendering, feel free to ignore this pull request... I'll understand  ;)
